### PR TITLE
PHP8 support, some fixes

### DIFF
--- a/php_gearman.c
+++ b/php_gearman.c
@@ -146,6 +146,9 @@ ZEND_END_ARG_INFO()
 /*
  * Gearman Job Functions
  */
+ZEND_BEGIN_ARG_INFO_EX(arginfo_oo_gearman_job_destruct, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_gearman_job_return_code, 0, 0, 1)
 	ZEND_ARG_INFO(0, job_object)
 ZEND_END_ARG_INFO()
@@ -261,6 +264,9 @@ ZEND_END_ARG_INFO()
 
 // Objected Oriented method for creating a GearmanClient object
 ZEND_BEGIN_ARG_INFO_EX(arginfo_gearman_client_construct, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_oo_gearman_client_destruct, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_gearman_client_return_code, 0, 0, 1)
@@ -707,6 +713,9 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO_EX(arginfo_oo_gearman_worker_construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_oo_gearman_worker_destruct, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_gearman_worker_error, 0, 0, 1)
 	ZEND_ARG_INFO(0, worker_object)
 ZEND_END_ARG_INFO()
@@ -1039,6 +1048,7 @@ zend_function_entry gearman_methods[]= {
 
 static zend_function_entry gearman_client_methods[]= {
 	PHP_ME(GearmanClient, __construct, arginfo_gearman_client_construct, ZEND_ACC_CTOR | ZEND_ACC_PUBLIC)
+	PHP_ME(GearmanClient, __destruct, arginfo_oo_gearman_client_destruct, ZEND_ACC_PUBLIC)
 	PHP_ME_MAPPING(returnCode, gearman_client_return_code, arginfo_oo_gearman_client_return_code, ZEND_ACC_PUBLIC)
 	PHP_ME_MAPPING(error, gearman_client_error, arginfo_oo_gearman_client_error, ZEND_ACC_PUBLIC)
 	PHP_ME_MAPPING(getErrno, gearman_client_get_errno, arginfo_oo_gearman_client_get_errno, ZEND_ACC_PUBLIC)
@@ -1107,6 +1117,7 @@ zend_function_entry gearman_task_methods[]= {
 
 zend_function_entry gearman_worker_methods[]= {
 	PHP_ME(GearmanWorker, __construct, arginfo_oo_gearman_worker_construct, ZEND_ACC_CTOR | ZEND_ACC_PUBLIC)
+	PHP_ME(GearmanWorker, __destruct, arginfo_oo_gearman_worker_destruct, ZEND_ACC_PUBLIC)
 	PHP_ME_MAPPING(returnCode, gearman_worker_return_code, arginfo_oo_gearman_worker_return_code, ZEND_ACC_PUBLIC)
 	PHP_ME_MAPPING(error, gearman_worker_error, arginfo_oo_gearman_worker_error, ZEND_ACC_PUBLIC)
 	PHP_ME_MAPPING(getErrno, gearman_worker_errno, arginfo_oo_gearman_worker_errno, ZEND_ACC_PUBLIC)
@@ -1131,6 +1142,7 @@ zend_function_entry gearman_worker_methods[]= {
 };
 
 zend_function_entry gearman_job_methods[]= {
+    PHP_ME(GearmanJob, __destruct, arginfo_oo_gearman_job_destruct, ZEND_ACC_PUBLIC)
 	PHP_ME_MAPPING(returnCode, gearman_job_return_code, arginfo_oo_gearman_job_return_code, ZEND_ACC_PUBLIC)
 	PHP_ME_MAPPING(setReturn, gearman_job_set_return, arginfo_oo_gearman_job_set_return, ZEND_ACC_PUBLIC)
 	PHP_ME_MAPPING(sendData, gearman_job_send_data, arginfo_oo_gearman_job_send_data, ZEND_ACC_PUBLIC)
@@ -1162,7 +1174,7 @@ PHP_MINIT_FUNCTION(gearman) {
 	gearman_client_obj_handlers.free_obj = gearman_client_free_obj;
 
 	INIT_CLASS_ENTRY(ce_task, "GearmanTask", gearman_task_methods);
-    gearman_task_ce = zend_register_internal_class(&ce_task);
+	gearman_task_ce = zend_register_internal_class(&ce_task);
 	gearman_task_ce->create_object = gearman_task_obj_new;
 	memcpy(&gearman_task_obj_handlers, zend_get_std_object_handlers(), sizeof(gearman_task_obj_handlers));
 	gearman_task_obj_handlers.offset = XtOffsetOf(gearman_task_obj, std);

--- a/php_gearman.c
+++ b/php_gearman.c
@@ -54,20 +54,11 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO_EX(arginfo_oo_gearman_task_construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_oo_gearman_task_destruct, 0, 0, 0)
-ZEND_END_ARG_INFO()
-
 ZEND_BEGIN_ARG_INFO_EX(arginfo_gearman_task_return_code, 0, 0, 1)
 	ZEND_ARG_INFO(0, task_object)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_oo_gearman_task_return_code, 0, 0, 0)
-ZEND_END_ARG_INFO()
-
-/* TODO: so looks like I may have implemented this incorrectly for
- * now no oo interface exist. I will need to come back to this later */
-ZEND_BEGIN_ARG_INFO_EX(arginfo_gearman_task_context, 0, 0, 1)
-	ZEND_ARG_INFO(0, task_object)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_gearman_task_function_name, 0, 0, 1)
@@ -155,9 +146,6 @@ ZEND_END_ARG_INFO()
 /*
  * Gearman Job Functions
  */
-ZEND_BEGIN_ARG_INFO_EX(arginfo_oo_gearman_job_destruct, 0, 0, 0)
-ZEND_END_ARG_INFO()
-
 ZEND_BEGIN_ARG_INFO_EX(arginfo_gearman_job_return_code, 0, 0, 1)
 	ZEND_ARG_INFO(0, job_object)
 ZEND_END_ARG_INFO()
@@ -273,9 +261,6 @@ ZEND_END_ARG_INFO()
 
 // Objected Oriented method for creating a GearmanClient object
 ZEND_BEGIN_ARG_INFO_EX(arginfo_gearman_client_construct, 0, 0, 0)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_oo_gearman_client_destruct, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_gearman_client_return_code, 0, 0, 1)
@@ -695,9 +680,6 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_oo_gearman_client_set_context, 0, 0, 1)
 	ZEND_ARG_INFO(0, context)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_gearman_client_enable_exception_handler, 0, 0, 0)
-ZEND_END_ARG_INFO()
-
 ZEND_BEGIN_ARG_INFO_EX(arginfo_oo_gearman_client_enable_exception_handler, 0, 0,0)
 ZEND_END_ARG_INFO()
 
@@ -723,9 +705,6 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_gearman_worker_create, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_oo_gearman_worker_construct, 0, 0, 0)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_oo_gearman_worker_destruct, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_gearman_worker_error, 0, 0, 1)
@@ -1173,39 +1152,39 @@ zend_function_entry gearman_exception_methods[] = {
 };
 
 PHP_MINIT_FUNCTION(gearman) {
-	zend_class_entry ce;
+	zend_class_entry ce_client, ce_task, ce_worker, ce_job, ce_exception;
 
-	INIT_CLASS_ENTRY(ce, "GearmanClient", gearman_client_methods);
-	gearman_client_ce = zend_register_internal_class(&ce);
+	INIT_CLASS_ENTRY(ce_client, "GearmanClient", gearman_client_methods);
+	gearman_client_ce = zend_register_internal_class(&ce_client);
 	gearman_client_ce->create_object = gearman_client_obj_new;
 	memcpy(&gearman_client_obj_handlers, zend_get_std_object_handlers(), sizeof(gearman_client_obj_handlers));
 	gearman_client_obj_handlers.offset = XtOffsetOf(gearman_client_obj, std);
 	gearman_client_obj_handlers.free_obj = gearman_client_free_obj;
 
-	INIT_CLASS_ENTRY(ce, "GearmanTask", gearman_task_methods);
-	gearman_task_ce = zend_register_internal_class(&ce);
+	INIT_CLASS_ENTRY(ce_task, "GearmanTask", gearman_task_methods);
+    gearman_task_ce = zend_register_internal_class(&ce_task);
 	gearman_task_ce->create_object = gearman_task_obj_new;
 	memcpy(&gearman_task_obj_handlers, zend_get_std_object_handlers(), sizeof(gearman_task_obj_handlers));
 	gearman_task_obj_handlers.offset = XtOffsetOf(gearman_task_obj, std);
 	gearman_task_obj_handlers.free_obj = gearman_task_free_obj;
 
-	INIT_CLASS_ENTRY(ce, "GearmanWorker", gearman_worker_methods);
-	gearman_worker_ce = zend_register_internal_class(&ce);
+	INIT_CLASS_ENTRY(ce_worker, "GearmanWorker", gearman_worker_methods);
+	gearman_worker_ce = zend_register_internal_class(&ce_worker);
 	gearman_worker_ce->create_object = gearman_worker_obj_new;
-	memcpy(&gearman_worker_obj_handlers, zend_get_std_object_handlers(), sizeof(gearman_worker_obj_handlers));
+	memcpy(&gearman_worker_obj_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
 	gearman_worker_obj_handlers.offset = XtOffsetOf(gearman_worker_obj, std);
 	gearman_worker_obj_handlers.free_obj = gearman_worker_free_obj;
 
-	INIT_CLASS_ENTRY(ce, "GearmanJob", gearman_job_methods);
-	gearman_job_ce = zend_register_internal_class(&ce);
+	INIT_CLASS_ENTRY(ce_job, "GearmanJob", gearman_job_methods);
+	gearman_job_ce = zend_register_internal_class(&ce_job);
 	gearman_job_ce->create_object = gearman_job_obj_new;
 	memcpy(&gearman_job_obj_handlers, zend_get_std_object_handlers(), sizeof(gearman_job_obj_handlers));
 	gearman_job_obj_handlers.offset = XtOffsetOf(gearman_job_obj, std);
 	gearman_job_obj_handlers.free_obj = gearman_job_free_obj;
 
 	/* XXX exception class */
-	INIT_CLASS_ENTRY(ce, "GearmanException", gearman_exception_methods)
-	gearman_exception_ce = zend_register_internal_class_ex(&ce, zend_exception_get_default());
+	INIT_CLASS_ENTRY(ce_exception, "GearmanException", gearman_exception_methods)
+	gearman_exception_ce = zend_register_internal_class_ex(&ce_exception, zend_exception_get_default());
 	gearman_exception_ce->ce_flags |= ZEND_ACC_FINAL;
 	zend_declare_property_long(gearman_exception_ce, "code", sizeof("code")-1, 0, ZEND_ACC_PUBLIC);
 

--- a/php_gearman_client.c
+++ b/php_gearman_client.c
@@ -72,18 +72,31 @@ PHP_METHOD(GearmanClient, __construct)
 }
 /* }}} */
 
-void gearman_client_free_obj(zend_object *object) {
+/* {{{ proto object GearmanClient::__destruct()
+   cleans up GearmanClient object */
+PHP_METHOD(GearmanClient, __destruct)
+{
         char *context = NULL;
-        gearman_client_obj *intern = gearman_client_fetch_object(object);
+        gearman_client_obj *intern = Z_GEARMAN_CLIENT_P(getThis());
         if (!intern) {
                 return;
         }
 
-        context = gearman_client_context(&(intern->client));
-        efree(context);
-
         if (intern->flags & GEARMAN_CLIENT_OBJ_CREATED) {
+                context = gearman_client_context(&(intern->client));
+                efree(context);
+
                 gearman_client_free(&intern->client);
+                intern->flags &= ~GEARMAN_CLIENT_OBJ_CREATED;
+        }
+}
+/* }}} */
+
+void gearman_client_free_obj(zend_object *object) {
+        gearman_client_obj *intern = gearman_client_fetch_object(object);
+
+        if (!intern) {
+                return;
         }
 
         // Clear Callbacks
@@ -100,7 +113,6 @@ void gearman_client_free_obj(zend_object *object) {
 
         zend_object_std_dtor(&intern->std);
 }
-/* }}} */
 
 /* {{{ proto int gearman_client_return_code()
    get last gearman_return_t */

--- a/php_gearman_client.c
+++ b/php_gearman_client.c
@@ -46,6 +46,7 @@ PHP_FUNCTION(gearman_client_create) {
 
         gearman_client_ctor(INTERNAL_FUNCTION_PARAM_PASSTHRU);
 }
+/* }}} */
 
 inline zend_object *gearman_client_obj_new(zend_class_entry *ce) {
 	gearman_client_obj *intern = ecalloc(1,
@@ -99,6 +100,7 @@ void gearman_client_free_obj(zend_object *object) {
 
         zend_object_std_dtor(&intern->std);
 }
+/* }}} */
 
 /* {{{ proto int gearman_client_return_code()
    get last gearman_return_t */
@@ -130,7 +132,7 @@ PHP_FUNCTION(gearman_client_error) {
 
         error = (char *)gearman_client_error(&(obj->client));
         if (error) {
-                RETURN_STRING(error)
+                RETURN_STRING(error);
         }    
         RETURN_FALSE;
 }
@@ -147,7 +149,7 @@ PHP_FUNCTION(gearman_client_get_errno) {
         }    
         obj = Z_GEARMAN_CLIENT_P(zobj);
 
-        RETURN_LONG(gearman_client_errno(&(obj->client)))
+        RETURN_LONG(gearman_client_errno(&(obj->client)));
 }
 /* }}} */
 
@@ -162,7 +164,7 @@ PHP_FUNCTION(gearman_client_options) {
         }    
         obj = Z_GEARMAN_CLIENT_P(zobj);
 
-        RETURN_LONG(gearman_client_options(&(obj->client)))
+        RETURN_LONG(gearman_client_options(&(obj->client)));
 }
 /* }}} */
 
@@ -230,7 +232,7 @@ PHP_FUNCTION(gearman_client_timeout) {
         }    
         obj = Z_GEARMAN_CLIENT_P(zobj);
 
-        RETURN_LONG(gearman_client_timeout(&(obj->client)))
+        RETURN_LONG(gearman_client_timeout(&(obj->client)));
 }
 /* }}} */
 
@@ -519,7 +521,7 @@ PHP_FUNCTION(gearman_client_do_job_handle) {
         obj = Z_GEARMAN_CLIENT_P(zobj);
 
 
-        RETURN_STRING((char *)gearman_client_do_job_handle(&(obj->client)))
+        RETURN_STRING((char *)gearman_client_do_job_handle(&(obj->client)));
 }
 /* }}} */
 
@@ -1177,13 +1179,21 @@ PHP_FUNCTION(gearman_client_clear_callbacks) {
         gearman_client_clear_fn(&obj->client);
 
         zval_dtor(&obj->zworkload_fn);
+        ZVAL_UNDEF(&obj->zworkload_fn);
         zval_dtor(&obj->zcreated_fn);
+        ZVAL_UNDEF(&obj->zcreated_fn);
         zval_dtor(&obj->zdata_fn);
+        ZVAL_UNDEF(&obj->zdata_fn);
         zval_dtor(&obj->zwarning_fn);
+        ZVAL_UNDEF(&obj->zwarning_fn);
         zval_dtor(&obj->zstatus_fn);
+        ZVAL_UNDEF(&obj->zstatus_fn);
         zval_dtor(&obj->zcomplete_fn);
+        ZVAL_UNDEF(&obj->zcomplete_fn);
         zval_dtor(&obj->zexception_fn);
+        ZVAL_UNDEF(&obj->zexception_fn);
         zval_dtor(&obj->zfail_fn);
+        ZVAL_UNDEF(&obj->zfail_fn);
 
         RETURN_TRUE;
 }

--- a/php_gearman_client.h
+++ b/php_gearman_client.h
@@ -76,6 +76,7 @@ void gearman_client_free_obj(zend_object *object);
 
 PHP_FUNCTION(gearman_client_create);
 PHP_METHOD(GearmanClient, __construct);
+PHP_METHOD(GearmanClient, __destruct);
 PHP_FUNCTION(gearman_client_return_code);
 PHP_FUNCTION(gearman_client_error);
 PHP_FUNCTION(gearman_client_get_errno);

--- a/php_gearman_job.c
+++ b/php_gearman_job.c
@@ -27,20 +27,30 @@ zend_object *gearman_job_obj_new(zend_class_entry *ce) {
         return &intern->std;
 }
 
-/* {{{ gearman_job_free_obj */
-void gearman_job_free_obj(zend_object *object) {
-        gearman_job_obj *intern = gearman_job_fetch_object(object);
+/* {{{ proto object GearmanJob::__destruct()
+   cleans up GearmanJob object */
+PHP_METHOD(GearmanJob, __destruct) {
+        gearman_job_obj *intern = Z_GEARMAN_JOB_P(getThis());
         if (!intern) {
                 return;
         }
 
         if (intern->flags & GEARMAN_JOB_OBJ_CREATED) {
-                gearman_job_free(intern->job);
+				gearman_job_free(intern->job);
+				intern->flags &= ~GEARMAN_JOB_OBJ_CREATED;
+        }
+}
+/* }}} */
+
+void gearman_job_free_obj(zend_object *object) {
+        gearman_job_obj *intern = gearman_job_fetch_object(object);
+
+        if (!intern) {
+               return;
         }
 
         zend_object_std_dtor(&intern->std);
 }
-/* }}} */
 
 /* {{{ proto int gearman_job_return_code()
    get last gearman_return_t */

--- a/php_gearman_job.c
+++ b/php_gearman_job.c
@@ -256,7 +256,7 @@ PHP_FUNCTION(gearman_job_handle) {
 		RETURN_FALSE;
 	}
 
-	RETURN_STRING((char *)gearman_job_handle(obj->job))
+	RETURN_STRING((char *)gearman_job_handle(obj->job));
 }
 /* }}} */
 
@@ -276,7 +276,7 @@ PHP_FUNCTION(gearman_job_function_name) {
 		RETURN_FALSE;
 	}
 
-	RETURN_STRING((char *)gearman_job_function_name(obj->job))
+	RETURN_STRING((char *)gearman_job_function_name(obj->job));
 }
 /* }}} */
 
@@ -296,7 +296,7 @@ PHP_FUNCTION(gearman_job_unique) {
 		RETURN_FALSE;
 	}
 
-	RETURN_STRING((char *)gearman_job_unique(obj->job))
+	RETURN_STRING((char *)gearman_job_unique(obj->job));
 }
 /* }}} */
 

--- a/php_gearman_job.h
+++ b/php_gearman_job.h
@@ -47,6 +47,7 @@ gearman_job_obj *gearman_job_fetch_object(zend_object *obj);
 
 void gearman_job_free_obj(zend_object *object);
 
+PHP_METHOD(GearmanJob, __destruct);
 PHP_FUNCTION(gearman_job_return_code);
 PHP_FUNCTION(gearman_job_set_return);
 PHP_FUNCTION(gearman_job_send_data);

--- a/php_gearman_task.c
+++ b/php_gearman_task.c
@@ -45,7 +45,7 @@ gearman_return_t _php_task_cb_fn(gearman_task_obj *task, gearman_client_obj *cli
                 param_count = 2; 
         }    
 
-        if (call_user_function_ex(EG(function_table), NULL, &zcall, &retval, param_count, argv, 0, NULL) != SUCCESS) {
+        if (call_user_function(EG(function_table), NULL, &zcall, &retval, param_count, argv) != SUCCESS) {
                 php_error_docref(NULL,
                                 E_WARNING,
                                 "Could not call the function %s",

--- a/php_gearman_task.c
+++ b/php_gearman_task.c
@@ -126,12 +126,14 @@ gearman_return_t _php_task_fail_fn(gearman_task_st *task) {
    Returns a task object */
 PHP_METHOD(GearmanTask, __construct) {
 }
+/* }}} */
 
 void gearman_task_free_obj(zend_object *object) {
         gearman_task_obj *intern = gearman_task_fetch_object(object);
+
         if (!intern) {
                 return;
-        }    
+        }
 
         zval_dtor(&intern->zworkload);
         zval_dtor(&intern->zdata);

--- a/php_gearman_worker.c
+++ b/php_gearman_worker.c
@@ -57,8 +57,10 @@ PHP_METHOD(GearmanWorker, __construct) {
 }
 /* }}} */
 
-void gearman_worker_free_obj(zend_object *object) {
-    gearman_worker_obj *intern = gearman_worker_fetch_object(object);
+/* {{{ proto object GearmanWorker::__destruct()
+   Destroys a worker object */
+PHP_METHOD(GearmanWorker, __destruct) {
+    gearman_worker_obj *intern = Z_GEARMAN_WORKER_P(getThis());
 
 	if (!intern)  {
 		return;
@@ -66,12 +68,22 @@ void gearman_worker_free_obj(zend_object *object) {
 
 	if (intern->flags & GEARMAN_WORKER_OBJ_CREATED) {
 		gearman_worker_free(&(intern->worker));
+		intern->flags &= ~GEARMAN_WORKER_OBJ_CREATED;
 	}
 
 	zval_dtor(&intern->cb_list);
-	zend_object_std_dtor(&intern->std);
 }
 /* }}} */
+
+void gearman_worker_free_obj(zend_object *object) {
+	gearman_worker_obj *intern = gearman_worker_fetch_object(object);
+
+	if (!intern)  {
+		return;
+	}
+
+	zend_object_std_dtor(&intern->std);
+}
 
 static inline void cb_list_dtor(zval *zv) {
 	gearman_worker_cb_obj *worker_cb = Z_PTR_P(zv);

--- a/php_gearman_worker.c
+++ b/php_gearman_worker.c
@@ -142,7 +142,7 @@ PHP_FUNCTION(gearman_worker_errno) {
         }    
         obj = Z_GEARMAN_WORKER_P(zobj);
 
-        RETURN_LONG(gearman_worker_errno(&(obj->worker)))
+        RETURN_LONG(gearman_worker_errno(&(obj->worker)));
 }
 /* }}} */
 
@@ -157,7 +157,7 @@ PHP_FUNCTION(gearman_worker_options) {
         }    
         obj = Z_GEARMAN_WORKER_P(zobj);
 
-        RETURN_LONG(gearman_worker_options(&(obj->worker)))
+        RETURN_LONG(gearman_worker_options(&(obj->worker)));
 }
 /* }}} */
 
@@ -223,7 +223,7 @@ PHP_FUNCTION(gearman_worker_timeout) {
         }    
         obj = Z_GEARMAN_WORKER_P(zobj);
 
-        RETURN_LONG(gearman_worker_timeout(&(obj->worker)))
+        RETURN_LONG(gearman_worker_timeout(&(obj->worker)));
 }
 /* }}} */
 
@@ -495,7 +495,7 @@ static void *_php_worker_function_callback(gearman_job_st *job,
 
         jobj->ret = GEARMAN_SUCCESS;
 
-        if (call_user_function_ex(EG(function_table), NULL, &worker_cb->zcall, &retval, param_count, argv, 0, NULL) != SUCCESS) {
+        if (call_user_function(EG(function_table), NULL, &worker_cb->zcall, &retval, param_count, argv) != SUCCESS) {
                 php_error_docref(NULL,
                                 E_WARNING,
                                 "Could not call the function %s",

--- a/php_gearman_worker.h
+++ b/php_gearman_worker.h
@@ -58,6 +58,7 @@ void gearman_worker_free_obj(zend_object *object);
 
 PHP_FUNCTION(gearman_worker_create);
 PHP_METHOD(GearmanWorker, __construct);
+PHP_METHOD(GearmanWorker, __destruct);
 PHP_FUNCTION(gearman_worker_return_code);
 PHP_FUNCTION(gearman_worker_error);
 PHP_FUNCTION(gearman_worker_errno);

--- a/tests/gearman_worker_010.phpt
+++ b/tests/gearman_worker_010.phpt
@@ -1,10 +1,11 @@
 --TEST--
 gearman_worker_add_server(), gearman_worker_add_servers()
 --SKIPIF--
-<?php if (!extension_loaded("gearman")) print "skip"; ?>
+<?php if (!extension_loaded("gearman")) print "skip";
 /*
 TODO - requires gearmand to be running
 */
+?>
 --FILE--
 <?php 
 

--- a/tests/gearman_worker_012.phpt
+++ b/tests/gearman_worker_012.phpt
@@ -1,10 +1,11 @@
 --TEST--
 gearman_worker_register(), gearman_worker_unregister(), gearman_worker_unregister_all()
 --SKIPIF--
-<?php if (!extension_loaded("gearman")) print "skip"; ?>
+<?php if (!extension_loaded("gearman")) print "skip";
 /*
 TODO - requires gearmand to be running
 */
+?>
 --FILE--
 <?php 
 

--- a/tests/gearman_worker_013.phpt
+++ b/tests/gearman_worker_013.phpt
@@ -1,10 +1,11 @@
 --TEST--
 gearman_worker_add_function()
 --SKIPIF--
-<?php if (!extension_loaded("gearman")) print "skip"; ?>
+<?php if (!extension_loaded("gearman")) print "skip";
 /*
 TODO - requires gearmand to be running
 */
+?>
 --FILE--
 <?php 
 

--- a/tests/gearman_worker_014.phpt
+++ b/tests/gearman_worker_014.phpt
@@ -1,10 +1,11 @@
 --TEST--
 gearman_worker_work()
 --SKIPIF--
-<?php if (!extension_loaded("gearman")) print "skip"; ?>
+<?php if (!extension_loaded("gearman")) print "skip";
 /*
 TODO - requires gearmand to be running
 */
+?>
 --FILE--
 <?php 
 

--- a/tests/gearman_worker_015.phpt
+++ b/tests/gearman_worker_015.phpt
@@ -1,10 +1,11 @@
 --TEST--
 gearman_worker_echo()
 --SKIPIF--
-<?php if (!extension_loaded("gearman")) print "skip"; ?>
+<?php if (!extension_loaded("gearman")) print "skip";
 /*
 TODO - requires gearmand to be running
 */
+?>
 --FILE--
 <?php 
 

--- a/tests/gearman_worker_016.phpt
+++ b/tests/gearman_worker_016.phpt
@@ -1,10 +1,11 @@
 --TEST--
 GearmanWorker::addFunction(), context param
 --SKIPIF--
-<?php if (!extension_loaded("gearman")) print "skip"; ?>
+<?php if (!extension_loaded("gearman")) print "skip";
 /*
 TODO - requires gearmand to be running
 */
+?>
 --FILE--
 <?php 
 $host = 'localhost';

--- a/tests/gearman_worker_integration_test_001.phpt
+++ b/tests/gearman_worker_integration_test_001.phpt
@@ -18,7 +18,7 @@ if ($pid == -1) {
     // Parent. This is the worker
     $worker = new GearmanWorker();
     print "addServer: " . var_export($worker->addServer($host, $port), true) . PHP_EOL;
-    print "setTimeout: " . var_export($worker->setTimeout(5), true) . PHP_EOL;
+    print "setTimeout: " . var_export($worker->setTimeout(200), true) . PHP_EOL;
     print "register: " . var_export($worker->register($job_name, 5), true) . PHP_EOL;
     print "register: " . var_export($worker->register($job_name . "1", 5), true) . PHP_EOL;
     print "register: " . var_export($worker->register($job_name . "2", 5), true) . PHP_EOL;

--- a/tests/skipifconnect.inc
+++ b/tests/skipifconnect.inc
@@ -2,22 +2,18 @@
 
 require_once('connect.inc');
 
-$sock = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+$sock = fsockopen($host, $port);
 if ($sock === false) {
-    die("skip unable to create socket");
-}
-
-if (socket_connect($sock, $host, $port) !== true) {
     die("skip unable to connect");
 }
 
 $command = "getpid\n";
-if (socket_write($sock, $command) !== strlen($command)) {
+if (fwrite($sock, $command) !== strlen($command)) {
     die("skip unable to write getpid");
 }
 
-if (socket_read($sock, 8) === false) {
+if (fread($sock, 8) === false) {
     die("skip unable to read pid");
 }
 
-socket_close($sock);
+fclose($sock);


### PR DESCRIPTION
1) Added PHP8 support based on this PR
https://github.com/php/pecl-networking-gearman/pull/3

2) Reworked [serialization bug fix](https://github.com/oleg-st/pecl-networking-gearman/pull/1) to fix memory leaks found during tests.

3) Removed sockets extension dependency in tests

4) Minor fixes: `gearman_client_clear_callbacks` etc